### PR TITLE
Add clock syscall

### DIFF
--- a/.gdbinit.tmpl-riscv
+++ b/.gdbinit.tmpl-riscv
@@ -1,0 +1,6 @@
+set confirm off
+set architecture riscv:rv64
+target remote 127.0.0.1:1234
+symbol-file kernel/kernel
+set disassemble-next-line auto
+set riscv use-compressed-breakpoints yes

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*~
+_*
+*.o
+*.d
+*.asm
+*.sym
+*.img
+vectors.S
+bootblock
+entryother
+initcode
+initcode.out
+kernelmemfs
+mkfs
+kernel/kernel
+user/usys.S
+.gdbinit

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o\
+  $K/timer.o
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin

--- a/kernel/kernelvec.S
+++ b/kernel/kernelvec.S
@@ -6,6 +6,9 @@
         # push all registers, call kerneltrap().
         # when kerneltrap() returns, restore registers, return.
         #
+#include "riscv.h"
+#include "memlayout.h"
+
 .globl kerneltrap
 .globl kernelvec
 .align 4
@@ -93,15 +96,11 @@ kernelvec:
 .globl timervec
 .align 4
 timervec:
-        # start.c has set up the memory that mscratch points to:
-        # scratch[0,8,16] : register save area.
-        # scratch[24] : address of CLINT's MTIMECMP register.
-        # scratch[32] : desired interval between interrupts.
         
-        csrrw a0, mscratch, a0
-        sd a1, 0(a0)
-        sd a2, 8(a0)
-        sd a3, 16(a0)
+        # csrrw a0, mscratch, a0
+        # sd a1, 0(a0)
+        # sd a2, 8(a0)
+        # sd a3, 16(a0)
 
         # schedule the next timer interrupt
         # by adding interval to mtimecmp.
@@ -122,3 +121,52 @@ timervec:
         csrrw a0, mscratch, a0
 
         mret
+
+.globl machinetrap
+.align 4
+machinetrap:
+        # start.c has set up the memory that mscratch points to:
+        # scratch[0,8,16] : register save area.
+        # scratch[24] : address of CLINT's MTIMECMP register.
+        # scratch[32] : desired interval between interrupts.
+        # scratch[40] : space to store clock value
+
+        # Store registers that need to be used
+        csrrw a0, mscratch, a0
+        sd a1, 0(a0)
+        sd a2, 8(a0)
+        sd a3, 16(a0)
+
+
+        csrr a1, mcause
+        li a2, MCTIMER
+        li a3, MCECALL
+        beq a1, a2, timervec
+        beq a1, a3, getclock
+
+infspin:
+        j infspin
+
+.global getclock
+.align 4
+getclock:
+
+        li a1, CLINT_MTIME
+        ld a2, 0(a1)
+        sd a2, 40(a0)
+
+        csrr a1, mepc
+        addi a1, a1, 4
+        csrw mepc, a1
+
+        ld a3, 16(a0)
+        ld a2, 8(a0)
+        ld a1, 0(a0)
+        csrrw a0, mscratch, a0
+        
+        // Return to the thread
+        mret
+
+
+
+

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -65,3 +65,5 @@
 //   TRAPFRAME (p->trapframe, used by the trampoline)
 //   TRAMPOLINE (the same page as in the kernel)
 #define TRAPFRAME (TRAMPOLINE - PGSIZE)
+#define MCTIMER ((1L<<63) + 7)
+#define MCECALL 9L

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -16,6 +16,7 @@ r_mhartid()
 #define MSTATUS_MPP_S (1L << 11)
 #define MSTATUS_MPP_U (0L << 11)
 #define MSTATUS_MIE (1L << 3)    // machine-mode interrupt enable.
+#define MEDELEG_S_ECALL (1<<9)
 
 static inline uint64
 r_mstatus()

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_clock(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_clock]   sys_clock,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_clock  22

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -5,6 +5,7 @@
 #include "memlayout.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "timer.h"
 
 uint64
 sys_exit(void)
@@ -88,4 +89,12 @@ sys_uptime(void)
   xticks = ticks;
   release(&tickslock);
   return xticks;
+}
+
+uint64
+sys_clock(void)
+{
+  uint64 clockval;
+  clockval = clock(cpuid());
+  return clockval;
 }

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -1,0 +1,18 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "riscv.h"
+#include "defs.h"
+
+#include "timer.h"
+
+/* Function declarations */
+
+uint64
+clock(int id)
+{
+    asm volatile ("ecall");
+    uint64 clockval = timer_scratch[id][5];
+
+    return clockval;
+}

--- a/kernel/timer.h
+++ b/kernel/timer.h
@@ -1,0 +1,13 @@
+#include "types.h"
+#include "param.h"
+
+/* 
+Function prototypes for functions in timer.c
+*/
+
+uint64 clock(int id);
+
+/* Extern variable declarations 
+These are global variables declared in other files. */
+
+extern uint64 timer_scratch[NCPU][6];

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+uint64 clock(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("clock");


### PR DESCRIPTION
The clock() syscall has been added. 

There are quite a few changes in the code, please refer to the latest commit message in addClockSyscall branch 
for the implementation details. 